### PR TITLE
Add odyssey.cfg for running resin prints

### DIFF
--- a/klipper/config/odyssey.cfg
+++ b/klipper/config/odyssey.cfg
@@ -1,0 +1,24 @@
+[gcode_shell_command odyssey_start]
+command: ~/printer_data/scripts/odyssey_start.sh
+timeout: 864000
+verbose: False
+
+[gcode_macro ODYSSEY_START]
+gcode:
+    M117 Printing with Odyssey! Stop with ODYSSEY_EMERGENCY_STOP
+    {action_respond_info("Starting mSLA print with Odyssey!")}
+    {action_respond_info("Please do not interfere with the print while in progress.")}
+    {action_respond_info("If you need to stop the print, use ODYSSEY_EMERGENCY_STOP")}
+    RUN_SHELL_COMMAND CMD=odyssey_start PARAMS="{params.FILE}"
+
+[gcode_shell_command odyssey_stop]
+command: ~/printer_data/scripts/odyssey_start.sh
+timeout: 864000
+verbose: False
+
+[gcode_macro ODYSSEY_EMERGENCY_STOP]
+gcode:
+    RUN_SHELL_COMMAND CMD=odyssey_stop PARAMS="{params.FILE}"
+    SET_PIN PIN=led_array VALUE=0
+    M117
+    {action_respond_info("Stopping Odyssey, turning off LED array.")}

--- a/klipper/config/odyssey.cfg
+++ b/klipper/config/odyssey.cfg
@@ -1,6 +1,6 @@
 [gcode_shell_command odyssey_start]
 command: ~/printer_data/scripts/odyssey_start.sh
-timeout: 864000
+timeout: 60
 verbose: False
 
 [gcode_macro ODYSSEY_START]
@@ -13,7 +13,7 @@ gcode:
 
 [gcode_shell_command odyssey_stop]
 command: ~/printer_data/scripts/odyssey_start.sh
-timeout: 864000
+timeout: 60
 verbose: False
 
 [gcode_macro ODYSSEY_EMERGENCY_STOP]

--- a/klipper/config/printer.cfg
+++ b/klipper/config/printer.cfg
@@ -14,7 +14,7 @@ enable_force_move: True
 [pause_resume]
 
 [virtual_sdcard]
-path: ~/printer_data/gcodes
+path: ~/printer_data/gcode
 
 [temperature_sensor klipper_host]
 sensor_type: temperature_host


### PR DESCRIPTION
Add odyssey.cfg, with odyssey_start, odyssey_stop, and associated gcode macros