### PR TITLE
NanoDLP: Fix shutter config and wait times

### DIFF
--- a/nanodlp/machine.json
+++ b/nanodlp/machine.json
@@ -21,7 +21,7 @@
 	"FaultPinState": 1,
 	"ShutterPin": 0,
 	"ShutterType": 0,
-	"ShutterMode": 1,
+	"ShutterMode": 2,
 	"ShutterOpen": 500,
 	"ShutterClose": 2500,
 	"ShutterOpenGcode": "UVLED_ON",

--- a/nanodlp/profiles.json
+++ b/nanodlp/profiles.json
@@ -69,7 +69,7 @@
 		"SeparationDetection": "",
 		"ResinLevelDetection": "",
 		"CrashDetection": "",
-		"DynamicWait": "",
+		"DynamicWait": "0",
 		"SlowSectionHeight": 7,
 		"SlowSectionStepWait": 40,
 		"JumpPerLayer": 0,


### PR DESCRIPTION
Fix shutter mode to not have nanodlp manage LED state itself Add "dynamicWait" of 0 to not have NanoDLP manage wait itself